### PR TITLE
⚡ Performance Optimization: Move regex compilation in RedisWafClient

### DIFF
--- a/ktor-service/src/main/kotlin/service/RedisWafClient.kt
+++ b/ktor-service/src/main/kotlin/service/RedisWafClient.kt
@@ -56,11 +56,8 @@ class RedisWafClient(redisUri: String) : AutoCloseable {
     // НА ДАННОМ ЭТАПЕ НЕ НУЖНА ИДЕАЛЬНАЯ PROD-READY ПРОВЕРКА
     // ДОСТАТОЧНО БАЗОВОГО МЕТОДА, КОТОРЫЙ БУДЕТ ДЕТАЛЬНО ПРОРАБОТАН В БУДУЩЕМ
     private fun sanitizeIp(ip: String): String {
-        val ipv4Regex = Regex("""^(\d{1,3}\.){3}\d{1,3}$""")
-        val ipv6Regex = Regex("""^([0-9a-fA-F]{0,4}:){2,7}[0-9a-fA-F]{0,4}$""")
-
         return when {
-            ipv4Regex.matches(ip) || ipv6Regex.matches(ip) -> {
+            IPV4_REGEX.matches(ip) || IPV6_REGEX.matches(ip) -> {
                 runCatching {
                     java.net.InetAddress.getByName(ip).hostAddress
                 }.getOrElse { ip }
@@ -73,5 +70,8 @@ class RedisWafClient(redisUri: String) : AutoCloseable {
         private const val BAN_KEY_PREFIX = "$WAF_PREFIX:ban:ip:"
         private const val MANUAL_BAN_KEY_PREFIX = "$WAF_PREFIX:manual_ban:ip:"
         private const val ACTIVE_RULES = "$WAF_PREFIX:active_rules"
+
+        private val IPV4_REGEX = Regex("""^(\d{1,3}\.){3}\d{1,3}$""")
+        private val IPV6_REGEX = Regex("""^([0-9a-fA-F]{0,4}:){2,7}[0-9a-fA-F]{0,4}$""")
     }
 }


### PR DESCRIPTION
💡 **What:** Moved `ipv4Regex` and `ipv6Regex` from the `sanitizeIp` method body to the `companion object` in `RedisWafClient`.

🎯 **Why:** Creating and compiling a `Regex` object on every method call is inefficient and can become a bottleneck, especially for high-throughput services like a WAF. Moving them to a `companion object` ensures they are compiled once and reused.

📊 **Measured Improvement:** Direct measurement in the sandbox environment was impractical due to persistent Gradle timeouts (>400s). However, this is a well-known JVM/Kotlin optimization that eliminates redundant object creation and pattern compilation. In theory, this should save several microseconds per call and reduce GC pressure.

---
*PR created automatically by Jules for task [7092857438608835470](https://jules.google.com/task/7092857438608835470) started by @Pavelgrr7*