### PR TITLE
Feat/admin kafka integration

### DIFF
--- a/admin-frontend/src/components/layout/Sidebar.tsx
+++ b/admin-frontend/src/components/layout/Sidebar.tsx
@@ -11,7 +11,7 @@ interface NavItem {
 
 const navItems: NavItem[] = [
   { label: 'Dashboard', path: '/', icon: <LayoutDashboard size={20} /> },
-  { label: 'Rule Management', path: '/rules', icon: <Shield size={20} />, badge: 'Soon' },
+  { label: 'Rule Management', path: '/rules', icon: <Shield size={20} /> },
   { label: 'Settings', path: '/settings', icon: <Settings size={20} />, badge: 'Soon' },
 ];
 

--- a/admin-frontend/src/context/AuthContext.tsx
+++ b/admin-frontend/src/context/AuthContext.tsx
@@ -11,6 +11,7 @@ interface AuthContextType {
   token: string | null;
   isAuthenticated: boolean;
   isLoading: boolean;
+  isInitializing: boolean;
   login: (credentials: LoginCredentials) => Promise<void>;
   logout: () => void;
 }
@@ -21,17 +22,25 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined);
  * AuthProvider — wraps the app and provides authentication state via context.
  */
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [user, setUser] = useState<User | null>(null);
+    const [user, setUser] = useState<User | null>(null);
   const [token, setToken] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [isInitializing, setIsInitializing] = useState(true);
 
   // Restore auth state from localStorage on mount
   useEffect(() => {
-    const storedToken = localStorage.getItem('token');
-    const storedUser = localStorage.getItem('user');
-    if (storedToken && storedUser) {
-      setToken(storedToken);
-      setUser(JSON.parse(storedUser));
+    try {
+      const storedToken = localStorage.getItem('token');
+      const storedUser = localStorage.getItem('user');
+      if (storedToken && storedUser) {
+        setToken(storedToken);
+        setUser(JSON.parse(storedUser));
+      }
+    } catch {
+      localStorage.removeItem('token');
+      localStorage.removeItem('user');
+    } finally {
+      setIsInitializing(false);
     }
   }, []);
 
@@ -57,11 +66,12 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
   return (
     <AuthContext.Provider
-      value={{
+            value={{
         user,
         token,
         isAuthenticated: !!token,
         isLoading,
+        isInitializing,
         login,
         logout,
       }}

--- a/admin-frontend/src/routes/ProtectedRoute.tsx
+++ b/admin-frontend/src/routes/ProtectedRoute.tsx
@@ -4,10 +4,15 @@ import { useAuth } from '../context/AuthContext';
 
 /**
  * ProtectedRoute — redirects to /login if user is not authenticated.
+ * Waits for localStorage restore (isInitializing) before making a decision.
  */
 const ProtectedRoute: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, isInitializing } = useAuth();
   const location = useLocation();
+
+  if (isInitializing) {
+    return null;
+  }
 
   if (!isAuthenticated) {
     return <Navigate to="/login" state={{ from: location }} replace />;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - 'JWT_SECRET=${JWT_SECRET}'
       - 'SPRING_DATA_REDIS_HOST=redis'
       - 'SPRING_DATA_REDIS_PORT=6379'
+      - 'SPRING_KAFKA_BOOTSTRAP_SERVERS=kafka:29092'
     depends_on:
       redis:
         condition: service_started

--- a/ktor-service/src/main/kotlin/kafka/KafkaTrafficProducer.kt
+++ b/ktor-service/src/main/kotlin/kafka/KafkaTrafficProducer.kt
@@ -2,13 +2,16 @@ package com.pavelryzh.kafka
 
 import com.pavelryzh.plugins.logger
 import com.pavelryzh.service.dto.KafkaEvent
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNamingStrategy
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.ProducerConfig
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.serialization.StringSerializer
 import java.util.Properties
 
+@OptIn(ExperimentalSerializationApi::class)
 class KafkaTrafficProducer(
     bootstrapServers: String,
 ): AutoCloseable {
@@ -23,6 +26,8 @@ class KafkaTrafficProducer(
     internal val json = Json {
         encodeDefaults = true
         ignoreUnknownKeys = true
+        namingStrategy = JsonNamingStrategy.SnakeCase
+
     }
 
     init {

--- a/spring-backend/src/main/kotlin/com/pavelryzh/firewallus/InitSpringFwAiApplication.kt
+++ b/spring-backend/src/main/kotlin/com/pavelryzh/firewallus/InitSpringFwAiApplication.kt
@@ -2,7 +2,9 @@ package com.pavelryzh.firewallus
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableAsync
 
+@EnableAsync
 @SpringBootApplication
 class InitSpringFwAiApplication
 

--- a/spring-backend/src/main/kotlin/com/pavelryzh/firewallus/incident/api/IncidentController.kt
+++ b/spring-backend/src/main/kotlin/com/pavelryzh/firewallus/incident/api/IncidentController.kt
@@ -1,55 +1,27 @@
 package com.pavelryzh.firewallus.incident.api
 
+import com.pavelryzh.firewallus.incident.service.IncidentNotificationService
 import com.pavelryzh.firewallus.incident.service.IncidentService
-import org.springframework.context.event.EventListener
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.web.PageableDefault
-import org.springframework.scheduling.annotation.Async
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
-import java.util.concurrent.CopyOnWriteArrayList
+
 
 @RestController
 @RequestMapping("/api/v1/incidents")
 @PreAuthorize("hasRole('ADMIN')")
-class IncidentController(private val incidentService: IncidentService) {
-
-    private val emitters = CopyOnWriteArrayList<SseEmitter>()
+class IncidentController(private val incidentService: IncidentService,
+                         private val notificationService: IncidentNotificationService
+) {
 
     @GetMapping("/stream")
     fun streamIncidents(): SseEmitter {
-        val emitter = SseEmitter(0L)
-        emitters.add(emitter)
-
-        emitter.onCompletion { emitters.remove(emitter) }
-        emitter.onTimeout { emitters.remove(emitter) }
-        emitter.onError { emitters.remove(emitter) }
-
-        return emitter
-    }
-
-    @Async
-    @EventListener
-    fun onNewIncident(incidentDto: IncidentResponseDto) {
-        val deadEmitters = mutableSetOf<SseEmitter>()
-
-        emitters.forEach { emitter ->
-            try {
-                emitter.send(
-                    SseEmitter.event()
-                        .name("new-incident")
-                        .data(incidentDto)
-                )
-            } catch (e: Exception) {
-                deadEmitters.add(emitter)
-            }
-        }
-
-        emitters.removeAll(deadEmitters)
+        return notificationService.createEmitter()
     }
 
     @GetMapping

--- a/spring-backend/src/main/kotlin/com/pavelryzh/firewallus/incident/api/IncidentController.kt
+++ b/spring-backend/src/main/kotlin/com/pavelryzh/firewallus/incident/api/IncidentController.kt
@@ -1,0 +1,63 @@
+package com.pavelryzh.firewallus.incident.api
+
+import com.pavelryzh.firewallus.incident.service.IncidentService
+import org.springframework.context.event.EventListener
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PageableDefault
+import org.springframework.scheduling.annotation.Async
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
+import java.util.concurrent.CopyOnWriteArrayList
+
+@RestController
+@RequestMapping("/api/v1/incidents")
+@PreAuthorize("hasRole('ADMIN')")
+class IncidentController(private val incidentService: IncidentService) {
+
+    private val emitters = CopyOnWriteArrayList<SseEmitter>()
+
+    @GetMapping("/stream")
+    fun streamIncidents(): SseEmitter {
+        val emitter = SseEmitter(0L)
+        emitters.add(emitter)
+
+        emitter.onCompletion { emitters.remove(emitter) }
+        emitter.onTimeout { emitters.remove(emitter) }
+        emitter.onError { emitters.remove(emitter) }
+
+        return emitter
+    }
+
+    @Async
+    @EventListener
+    fun onNewIncident(incidentDto: IncidentResponseDto) {
+        val deadEmitters = mutableSetOf<SseEmitter>()
+
+        emitters.forEach { emitter ->
+            try {
+                emitter.send(
+                    SseEmitter.event()
+                        .name("new-incident")
+                        .data(incidentDto)
+                )
+            } catch (e: Exception) {
+                deadEmitters.add(emitter)
+            }
+        }
+
+        emitters.removeAll(deadEmitters)
+    }
+
+    @GetMapping
+    fun getAllIncidents(
+        @PageableDefault(size = 20, page = 0) pageable: Pageable
+    ): Page<IncidentResponseDto> {
+
+        val incidentsPage = incidentService.getAllIncidents(pageable)
+        return incidentsPage.map { it.toDto() }
+    }
+}

--- a/spring-backend/src/main/kotlin/com/pavelryzh/firewallus/incident/api/IncidentDtos.kt
+++ b/spring-backend/src/main/kotlin/com/pavelryzh/firewallus/incident/api/IncidentDtos.kt
@@ -1,0 +1,51 @@
+package com.pavelryzh.firewallus.incident.api
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.pavelryzh.firewallus.incident.domain.Incident
+import com.pavelryzh.firewallus.rule.domain.IpAddress
+import java.time.Instant
+
+data class IncidentEventDto(
+    val incidentType: String,
+    val attackerIp: String,
+    val targetUri: String,
+    val actionTaken: String,
+    val confidenceScore: Float? = null,
+
+    @JsonProperty("headersDump")
+    val payloadDump: Map<String, String>
+) {
+    init {
+        require(incidentType.isNotBlank()) { "incidentType cannot be blank" }
+        require(attackerIp.isNotBlank()) { "attackerIp cannot be blank" }
+    }
+}
+
+data class IncidentResponseDto(
+    val incidentType: String,
+    val attackerIp: String,
+    val targetUri: String,
+    val actionTaken: String,
+    val confidenceScore: Float? = null,
+    val timestamp: Instant? = null,
+)
+
+fun IncidentEventDto.toEntity(): Incident = Incident(
+    incidentType = incidentType,
+    attackerIp = IpAddress(this.attackerIp),
+    targetUri = targetUri,
+    actionTaken = actionTaken,
+    confidenceScore = confidenceScore,
+    payloadDump = payloadDump,
+)
+
+fun Incident.toDto(): IncidentResponseDto {
+    return IncidentResponseDto(
+        incidentType = incidentType,
+        attackerIp = attackerIp.value,
+        targetUri = targetUri,
+        actionTaken = actionTaken,
+        confidenceScore = confidenceScore,
+        timestamp = timestamp
+    )
+}

--- a/spring-backend/src/main/kotlin/com/pavelryzh/firewallus/incident/api/IncidentDtos.kt
+++ b/spring-backend/src/main/kotlin/com/pavelryzh/firewallus/incident/api/IncidentDtos.kt
@@ -12,7 +12,7 @@ data class IncidentEventDto(
     val actionTaken: String,
     val confidenceScore: Float? = null,
 
-    @JsonProperty("headersDump")
+    @JsonProperty("headers_dump")
     val payloadDump: Map<String, String>
 ) {
     init {

--- a/spring-backend/src/main/kotlin/com/pavelryzh/firewallus/incident/domain/Incident.kt
+++ b/spring-backend/src/main/kotlin/com/pavelryzh/firewallus/incident/domain/Incident.kt
@@ -1,0 +1,47 @@
+package com.pavelryzh.firewallus.incident.domain
+
+import com.pavelryzh.firewallus.rule.domain.IpAddress
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.type.SqlTypes
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Table(name = "incident_logs")
+class Incident(
+    @Column(name = "incident_type", nullable = false)
+    var incidentType: String,
+
+    @Column(name = "attacker_ip", nullable = false)
+    var attackerIp: IpAddress,
+
+    @Column(name = "target_uri", nullable = false)
+    var targetUri: String,
+
+    @Column(name = "action_taken", nullable = false)
+    var actionTaken: String,
+
+    // Скор от ML. Nullable, так как для статических правил от Ktor его нет
+    @Column(name = "confidence_score")
+    var confidenceScore: Float? = null,
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "payload_dump", columnDefinition = "jsonb", nullable = false)
+    var payloadDump: Map<String, String>
+) {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "incident_id")
+    var id: UUID? = null
+
+    @CreationTimestamp
+    @Column(name = "timestamp", updatable = false)
+    var timestamp: Instant? = null
+}

--- a/spring-backend/src/main/kotlin/com/pavelryzh/firewallus/incident/port/IncidentListener.kt
+++ b/spring-backend/src/main/kotlin/com/pavelryzh/firewallus/incident/port/IncidentListener.kt
@@ -1,0 +1,4 @@
+package com.pavelryzh.firewallus.incident.port
+
+interface IncidentListener {
+}

--- a/spring-backend/src/main/kotlin/com/pavelryzh/firewallus/incident/port/IncidentRepository.kt
+++ b/spring-backend/src/main/kotlin/com/pavelryzh/firewallus/incident/port/IncidentRepository.kt
@@ -1,0 +1,10 @@
+package com.pavelryzh.firewallus.incident.port
+
+import com.pavelryzh.firewallus.incident.domain.Incident
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface IncidentRepository: JpaRepository<Incident, UUID> {
+}

--- a/spring-backend/src/main/kotlin/com/pavelryzh/firewallus/incident/service/IncidentNotificationService.kt
+++ b/spring-backend/src/main/kotlin/com/pavelryzh/firewallus/incident/service/IncidentNotificationService.kt
@@ -1,0 +1,45 @@
+package com.pavelryzh.firewallus.incident.service
+
+import com.pavelryzh.firewallus.incident.api.IncidentResponseDto
+import org.springframework.context.event.EventListener
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Service
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
+import java.util.concurrent.CopyOnWriteArrayList
+
+@Service
+class IncidentNotificationService {
+
+    private val emitters = CopyOnWriteArrayList<SseEmitter>()
+
+    fun createEmitter(): SseEmitter {
+        val emitter = SseEmitter(0L)
+        emitters.add(emitter)
+
+        emitter.onCompletion { emitters.remove(emitter) }
+        emitter.onTimeout { emitters.remove(emitter) }
+        emitter.onError { emitters.remove(emitter) }
+
+        return emitter
+    }
+
+    @Async
+    @EventListener
+    fun onNewIncident(incidentDto: IncidentResponseDto) {
+        val deadEmitters = mutableSetOf<SseEmitter>()
+
+        emitters.forEach { emitter ->
+            try {
+                emitter.send(
+                    SseEmitter.event()
+                        .name("new-incident")
+                        .data(incidentDto)
+                )
+            } catch (e: Exception) {
+                deadEmitters.add(emitter)
+            }
+        }
+
+        emitters.removeAll(deadEmitters)
+    }
+}

--- a/spring-backend/src/main/kotlin/com/pavelryzh/firewallus/incident/service/IncidentService.kt
+++ b/spring-backend/src/main/kotlin/com/pavelryzh/firewallus/incident/service/IncidentService.kt
@@ -1,0 +1,35 @@
+package com.pavelryzh.firewallus.incident.service
+
+import com.pavelryzh.firewallus.incident.api.IncidentEventDto
+import com.pavelryzh.firewallus.incident.api.toDto
+import com.pavelryzh.firewallus.incident.api.toEntity
+import com.pavelryzh.firewallus.incident.domain.Incident
+import com.pavelryzh.firewallus.incident.port.IncidentRepository
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+
+@Service
+class IncidentService(
+    private val incidentRepo: IncidentRepository,
+    private val eventPublisher: ApplicationEventPublisher
+) {
+
+    @Transactional
+    fun registerIncident(dto: IncidentEventDto): Incident {
+        val savedIncident = incidentRepo.save(dto.toEntity())
+
+        eventPublisher.publishEvent(savedIncident.toDto())
+
+        return savedIncident
+    }
+
+    @Transactional(readOnly = true)
+    fun getAllIncidents(pageable: Pageable): Page<Incident> {
+        return incidentRepo.findAll(pageable)
+    }
+
+
+}

--- a/spring-backend/src/main/kotlin/com/pavelryzh/firewallus/infra/IncidentKafkaListenerImpl.kt
+++ b/spring-backend/src/main/kotlin/com/pavelryzh/firewallus/infra/IncidentKafkaListenerImpl.kt
@@ -1,0 +1,23 @@
+package com.pavelryzh.firewallus.infra
+
+import com.pavelryzh.firewallus.incident.api.IncidentEventDto
+import com.pavelryzh.firewallus.incident.port.IncidentListener
+import com.pavelryzh.firewallus.incident.port.IncidentRepository
+import com.pavelryzh.firewallus.incident.service.IncidentService
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.stereotype.Component
+import tools.jackson.databind.ObjectMapper
+
+@Component
+class IncidentKafkaListenerImpl(
+    private val incidentService: IncidentService,
+    private val objectMapper: ObjectMapper
+): IncidentListener {
+
+    @KafkaListener(topics = ["incidents"], groupId = "spring-manager-group")
+    fun consumeIncident(message: String) {
+        val eventDto = objectMapper.readValue(message, IncidentEventDto::class.java)
+        incidentService.registerIncident(eventDto)
+
+    }
+}

--- a/spring-backend/src/main/kotlin/com/pavelryzh/firewallus/infra/api/IncidentKafkaListenerImpl.kt
+++ b/spring-backend/src/main/kotlin/com/pavelryzh/firewallus/infra/api/IncidentKafkaListenerImpl.kt
@@ -1,8 +1,7 @@
-package com.pavelryzh.firewallus.infra
+package com.pavelryzh.firewallus.infra.api
 
 import com.pavelryzh.firewallus.incident.api.IncidentEventDto
 import com.pavelryzh.firewallus.incident.port.IncidentListener
-import com.pavelryzh.firewallus.incident.port.IncidentRepository
 import com.pavelryzh.firewallus.incident.service.IncidentService
 import org.springframework.kafka.annotation.KafkaListener
 import org.springframework.stereotype.Component

--- a/spring-backend/src/main/kotlin/com/pavelryzh/firewallus/infra/api/RequestLoggingConfig.kt
+++ b/spring-backend/src/main/kotlin/com/pavelryzh/firewallus/infra/api/RequestLoggingConfig.kt
@@ -1,4 +1,4 @@
-package com.pavelryzh.firewallus.infra
+package com.pavelryzh.firewallus.infra.api
 
 import jakarta.servlet.http.HttpServletRequest
 import org.springframework.context.annotation.Bean

--- a/spring-backend/src/main/kotlin/com/pavelryzh/firewallus/infra/db/AdminSeeder.kt
+++ b/spring-backend/src/main/kotlin/com/pavelryzh/firewallus/infra/db/AdminSeeder.kt
@@ -1,8 +1,7 @@
-package com.pavelryzh.firewallus.infra
+package com.pavelryzh.firewallus.infra.db
 
 import com.pavelryzh.firewallus.user.AdminRepository
 import com.pavelryzh.firewallus.user.domain.Admin
-
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.ApplicationArguments

--- a/spring-backend/src/main/resources/db/migration/V2__add_incident_fields.sql
+++ b/spring-backend/src/main/resources/db/migration/V2__add_incident_fields.sql
@@ -1,0 +1,6 @@
+ALTER TABLE incident_logs
+    ADD COLUMN target_uri VARCHAR(255) NOT NULL DEFAULT '/',
+    ADD COLUMN action_taken VARCHAR(32) NOT NULL DEFAULT 'BLOCK';
+
+ALTER TABLE incident_logs ALTER COLUMN target_uri DROP DEFAULT;
+ALTER TABLE incident_logs ALTER COLUMN action_taken DROP DEFAULT;


### PR DESCRIPTION
## Incidents API
PR добавляет в admin panel backend слушатель инцидентов из kafka, а так же предоставляет api инцидентов для админ-панели. Один из фиксов затронул gataway-service (был изменён naming strategy в kafka producer'е).
Разработанный API позволяет создать дашборд с графиком инцидентов, обновляющимся в реальном времени (SSE), а так же отобрадать основные показатели WAF.

API протестирован через insomnia.

Closes https://github.com/Pavelgrr7/firewallus-ai-waf/issues/32