### PR TITLE
Feat/real proxy addres

### DIFF
--- a/ktor-service/src/main/kotlin/model/GlobalSettings.kt
+++ b/ktor-service/src/main/kotlin/model/GlobalSettings.kt
@@ -7,5 +7,6 @@ import kotlinx.serialization.Serializable
 data class GlobalSettings(
     @SerialName("rate_limit_requests") val limit: Int = 2000,
     @SerialName("rate_limit_window_sec") val window: Int = 60,
-    @SerialName("adaptive_mode_enabled") val adaptiveMode: Boolean = false
+    @SerialName("adaptive_mode_enabled") val adaptiveMode: Boolean = false,
+    @SerialName("target_url") val targetUrl: TargetUrl = TargetUrl("http://backend-spring:8080")
 )

--- a/ktor-service/src/main/kotlin/model/GlobalSettings.kt
+++ b/ktor-service/src/main/kotlin/model/GlobalSettings.kt
@@ -8,5 +8,5 @@ data class GlobalSettings(
     @SerialName("rate_limit_requests") val limit: Int = 2000,
     @SerialName("rate_limit_window_sec") val window: Int = 60,
     @SerialName("adaptive_mode_enabled") val adaptiveMode: Boolean = false,
-    @SerialName("target_url") val targetUrl: TargetUrl = TargetUrl("http://backend-spring:8080")
+    @SerialName("target_url") val targetUrl: TargetUrl = TargetUrl("http://backend:8080")
 )

--- a/ktor-service/src/main/kotlin/model/TargetUrl.kt
+++ b/ktor-service/src/main/kotlin/model/TargetUrl.kt
@@ -1,0 +1,18 @@
+package com.pavelryzh.model
+
+import kotlinx.serialization.Serializable
+
+@JvmInline
+@Serializable
+value class TargetUrl(val rawValue: String) {
+
+    init {
+        require(rawValue.trim().startsWith("http://") || rawValue.trim().startsWith("https://")) {
+            "Target URL must start with http:// or https://"
+        }
+    }
+
+    // Вычисляемое свойство: само уберет пробелы по краям и отрежет слеш на конце!
+    val normalized: String
+        get() = rawValue.trim().removeSuffix("/")
+}

--- a/ktor-service/src/main/kotlin/plugins/di/DI.kt
+++ b/ktor-service/src/main/kotlin/plugins/di/DI.kt
@@ -6,6 +6,7 @@ import com.pavelryzh.service.KtorHttpClient
 import com.pavelryzh.service.ProxyHttpClient
 import com.pavelryzh.service.RedisWafClient
 import com.pavelryzh.service.TrafficService
+import com.pavelryzh.service.WafConfigManager
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.HttpRequestRetry
@@ -48,8 +49,9 @@ fun Application.configureDI() {
                 wafRetryPolicy()
             }
         }} onClose { it?.close() }
+        single { WafConfigManager(get() ) } onCloseWith lifecycleLogger
         single { KtorHttpClient(get()) } onCloseWith lifecycleLogger bind ProxyHttpClient::class
-        single { TrafficService(get(), get(), get(), get()) } onCloseWith lifecycleLogger
+        single { TrafficService(get(), get(), get(), get(), get()) } onCloseWith lifecycleLogger
     }
 
     install(Koin) {

--- a/ktor-service/src/main/kotlin/service/KtorHttpClient.kt
+++ b/ktor-service/src/main/kotlin/service/KtorHttpClient.kt
@@ -1,32 +1,24 @@
 package com.pavelryzh.service
 
-import io.ktor.server.application.ApplicationCall
-import io.ktor.server.request.httpMethod
-import io.ktor.server.request.receiveChannel
-import io.ktor.server.request.uri
-
-import io.ktor.client.HttpClient
+import com.pavelryzh.model.TargetUrl
+import io.ktor.client.*
 import io.ktor.client.request.request
-
 import io.ktor.client.request.setBody
-import io.ktor.client.statement.bodyAsChannel
-import io.ktor.http.HttpHeaders
-import io.ktor.http.content.OutgoingContent
-import io.ktor.http.contentLength
-import io.ktor.http.contentType
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.http.content.*
 import io.ktor.http.headers
-import io.ktor.server.response.header
-import io.ktor.server.response.respond
-
-const val BACKEND_TARGET_URL = "http://backend-spring:8080"
+import io.ktor.server.application.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
 
 class KtorHttpClient(
     private val httpClient: HttpClient,
 ): AutoCloseable, ProxyHttpClient {
 
-    override suspend fun proxyToBackend(call: ApplicationCall, cachedBodyBytes: ByteArray?) {
+    override suspend fun proxyToBackend(targetUrl: TargetUrl, call: ApplicationCall, cachedBodyBytes: ByteArray?) {
 
-        val backendResponse = httpClient.request("$BACKEND_TARGET_URL${call.request.uri}") {
+        val backendResponse = httpClient.request("${targetUrl.normalized}${call.request.uri}") {
             method = call.request.httpMethod
             headers {
                 call.request.headers.forEach { key, values ->

--- a/ktor-service/src/main/kotlin/service/ProxyHttpClient.kt
+++ b/ktor-service/src/main/kotlin/service/ProxyHttpClient.kt
@@ -1,7 +1,8 @@
 package com.pavelryzh.service
 
+import com.pavelryzh.model.TargetUrl
 import io.ktor.server.application.ApplicationCall
 
 interface ProxyHttpClient {
-    suspend fun proxyToBackend(call: ApplicationCall, cachedBodyBytes: ByteArray?)
+    suspend fun proxyToBackend(targetUrl: TargetUrl, call: ApplicationCall, cachedBodyBytes: ByteArray?)
 }

--- a/ktor-service/src/main/kotlin/service/TrafficService.kt
+++ b/ktor-service/src/main/kotlin/service/TrafficService.kt
@@ -3,33 +3,20 @@ package com.pavelryzh.service
 import com.pavelryzh.core.IdentityExtractor
 import com.pavelryzh.core.WAF_PAYLOAD_LIMIT_BYTES
 import com.pavelryzh.core.WafRuleEngine
+import com.pavelryzh.core.extractTrafficLog
 import com.pavelryzh.kafka.KafkaTrafficProducer
 import com.pavelryzh.model.Action
-import com.pavelryzh.model.WafRule
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.launch
+import com.pavelryzh.model.TargetUrl
 import com.pavelryzh.plugins.logger
-import com.pavelryzh.core.extractTrafficLog
-import com.pavelryzh.model.GlobalSettings
 import com.pavelryzh.service.dto.HttpMethod
 import com.pavelryzh.service.dto.IncidentEventDto
 import com.pavelryzh.service.dto.parseMethod
-import io.ktor.http.HttpHeaders
-import io.ktor.http.HttpStatusCode
-import io.ktor.server.application.ApplicationCall
-import io.ktor.server.request.httpMethod
-import io.ktor.server.request.receiveChannel
-import io.ktor.server.request.uri
-import io.ktor.server.response.respond
-import io.ktor.utils.io.readRemaining
-import kotlinx.coroutines.CoroutineExceptionHandler
-import kotlinx.coroutines.cancelChildren
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.isActive
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withTimeoutOrNull
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.utils.io.*
+import kotlinx.coroutines.*
 import kotlinx.io.readByteArray
 
 class TrafficService(
@@ -37,6 +24,7 @@ class TrafficService(
     private val redisWafClient: RedisWafClient,
     private val ruleEngine: WafRuleEngine,
     private val httpClient: ProxyHttpClient,
+    private val configManager: WafConfigManager
     ) : AutoCloseable {
 
     private val logger = logger()
@@ -48,38 +36,19 @@ class TrafficService(
 
     private val serviceScope = CoroutineScope(scopeJob + Dispatchers.IO + exceptionHandler)
 
-    @Volatile
-    private var settings: GlobalSettings = GlobalSettings()
-
-    @Volatile
-    private var activeRules: List<WafRule> = emptyList()
-
-    init {
-        // Корутина раз в 10 секунд фетчит правила из Redis
-        serviceScope.launch {
-            while (isActive) {
-                activeRules = runCatching { redisWafClient.getActiveRules() }
-                    .getOrDefault(activeRules) // Redis упал -> старые правила
-
-                settings = runCatching { redisWafClient.getSettings() }
-                    .getOrNull() ?: settings
-
-                delay(10_000)
-            }
-        }
-    }
-
     suspend fun handleRequest(call: ApplicationCall) {
 
         val identity = IdentityExtractor.extract(call)
         val ip = identity.ip
+
+        val settings = configManager.settings.value
 
         // Проверка белого списка -> проверка банов -> проверка rate limit -> проврка правил
 
         val isWhitelisted = redisWafClient.isWhitelisted(identity.ip)
         if (isWhitelisted) {
             logger.debug("IP ${identity.ip} is whitelisted. Bypassing WAF.")
-            proxyToBackend(call, null)
+            proxyToBackend(settings.targetUrl, call, null)
             return
         }
         // Fail-Open: если Redis недоступен, разрешаем трафик (безопаснее, чем Fail-Closed)
@@ -91,6 +60,8 @@ class TrafficService(
             call.respond(HttpStatusCode.Forbidden, "Access Denied by WAF")
             return
         }
+
+        val activeRules = configManager.activeRules.value
 
         val isRateLimited = runCatching { redisWafClient.isRateLimited(ip, settings.limit, settings.window) }
             .getOrDefault(false) // Fail-Open
@@ -123,7 +94,7 @@ class TrafficService(
                 }
                 Action.ALLOW -> {
                     logger.info("Rule ${matchedRule.name} matched in ALLOW mode for IP $ip")
-                    proxyToBackend(call, cachedBodyBytes)
+                    proxyToBackend(settings.targetUrl, call, cachedBodyBytes)
                     return
                 }
             }
@@ -135,11 +106,11 @@ class TrafficService(
 
             )
         }
-        proxyToBackend(call, cachedBodyBytes)
+        proxyToBackend(settings.targetUrl, call, cachedBodyBytes)
     }
 
-    private suspend fun proxyToBackend(call: ApplicationCall, body: ByteArray?) {
-        httpClient.proxyToBackend(call, body)
+    private suspend fun proxyToBackend(targetUrl: TargetUrl, call: ApplicationCall, body: ByteArray?) {
+        httpClient.proxyToBackend(targetUrl, call, body)
     }
 
     private fun sendIncidentEvent(ip: String, uri: String, type: String, action: String, call: ApplicationCall, body: String?) {

--- a/ktor-service/src/main/kotlin/service/WafConfigManager.kt
+++ b/ktor-service/src/main/kotlin/service/WafConfigManager.kt
@@ -1,0 +1,40 @@
+package com.pavelryzh.service
+
+import com.pavelryzh.model.GlobalSettings
+import com.pavelryzh.model.WafRule
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+class WafConfigManager(
+    private val redisWafClient: RedisWafClient
+) : AutoCloseable {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    private val _settings = MutableStateFlow(GlobalSettings())
+    val settings: StateFlow<GlobalSettings> = _settings
+
+    private val _activeRules = MutableStateFlow<List<WafRule>>(emptyList())
+    val activeRules: StateFlow<List<WafRule>> = _activeRules
+
+    init {
+        scope.launch {
+            while (isActive) {
+                _settings.value = runCatching { redisWafClient.getSettings() }.getOrNull() ?: _settings.value
+                _activeRules.value = runCatching { redisWafClient.getActiveRules() }.getOrDefault(_activeRules.value)
+                delay(10_000)
+            }
+        }
+    }
+
+    override fun close() {
+        scope.cancel()
+    }
+}

--- a/spring-backend/src/main/kotlin/com/pavelryzh/firewallus/settings/api/SettingsResponseDto.kt
+++ b/spring-backend/src/main/kotlin/com/pavelryzh/firewallus/settings/api/SettingsResponseDto.kt
@@ -1,6 +1,7 @@
 package com.pavelryzh.firewallus.settings.api
 
 import com.pavelryzh.firewallus.settings.domain.WafSettings
+import jakarta.validation.constraints.Pattern
 
 
 data class SettingsResponseDto(
@@ -8,7 +9,8 @@ data class SettingsResponseDto(
     val rateLimitWindowSec: Int,
     val tgBotToken: String?,
     val tgChatId: String?,
-    val alertThreshold: Int
+    val alertThreshold: Int,
+    val targetUrl: String,
 )
 
 data class UpdateSettingsDto(
@@ -17,6 +19,11 @@ data class UpdateSettingsDto(
     val tgBotToken: String? = null,
     val tgChatId: String? = null,
     val alertThreshold: Int? = null,
+    @field:Pattern(
+        regexp = "^https?://.*",
+        message = "URL бэкенда должен начинаться с http:// или https://"
+    )
+    val targetUrl: String? = null
 )
 
 fun WafSettings.toDto(): SettingsResponseDto {
@@ -26,5 +33,6 @@ fun WafSettings.toDto(): SettingsResponseDto {
         tgBotToken = this.tgBotToken,
         tgChatId = this.tgChatId,
         alertThreshold = this.alertThreshold,
+        targetUrl = this.targetUrl
     )
 }

--- a/spring-backend/src/main/kotlin/com/pavelryzh/firewallus/settings/domain/WafSettings.kt
+++ b/spring-backend/src/main/kotlin/com/pavelryzh/firewallus/settings/domain/WafSettings.kt
@@ -24,7 +24,10 @@ class WafSettings(
     var tgChatId: String? = null,
 
     @Column(name = "alert_threshold", nullable = false)
-    var alertThreshold: Int = 50
+    var alertThreshold: Int = 50,
+
+    @Column(name = "target_url", nullable = false)
+    var targetUrl: String = "http://backend:8080"
 ) {
     @Id
     var id: Int = 1 // Всегда 1

--- a/spring-backend/src/main/kotlin/com/pavelryzh/firewallus/settings/service/WafSettingsService.kt
+++ b/spring-backend/src/main/kotlin/com/pavelryzh/firewallus/settings/service/WafSettingsService.kt
@@ -48,6 +48,8 @@ class WafSettingsService(
         updateDto.tgBotToken?.let { settings.tgBotToken = it }
         updateDto.tgChatId?.let { settings.tgChatId = it }
         updateDto.alertThreshold?.let { settings.alertThreshold = it }
+        updateDto.targetUrl?.let { settings.targetUrl = it }
+
         val adminId = currentAdminProvider.getCurrentAdminId()
 
         eventPublisher.publishEvent(SettingsUpdatedEvent(settings, adminId))


### PR DESCRIPTION
PR добавляет поддержу добавления адреса защищаемого ресурса через админ панель.
По мимо этого, в gateway-сервисе было реализовано чтение через redis и использование указанного адреса для передачи запросов. Следующий щаг - обновить ui, чтобы во вкладке настроек появилась возможность указать target url. Если останется время, можно будет сделать полноценную таблиц маршрутизации с импортом из yaml